### PR TITLE
Restructure R collaboration guide

### DIFF
--- a/ospsuite-r-specifics/CODING_STANDARDS_R.md
+++ b/ospsuite-r-specifics/CODING_STANDARDS_R.md
@@ -1,11 +1,11 @@
 # Coding Standards for R
 
-We will follow the <https://style.tidyverse.org/> style guide with very few changes to benefit from two R packages supporting this style guide:
+We will follow the <https://style.tidyverse.org/> style guide with very few changes to benefit from tools supporting this style guide:
 
-- [`{styler}`](http://styler.r-lib.org/)
-- [`{lintr}`](https://github.com/jimhester/lintr)
+- [`air`](https://posit-dev.github.io/air/) — the project formatter.
+- [`{lintr}`](https://github.com/jimhester/lintr) — linting.
 
-This coding standards will outline the more important aspects of the aforementioned style.
+These coding standards outline the more important aspects of the aforementioned style.
 
 # Modifications from tidyverse Coding Standards
 
@@ -168,7 +168,7 @@ If a class has a private method, its name should start with `.` to highlight thi
 
 ## Spacing
 
-Use the `styler` add-in for RStudio. It will style the files for you. For more, see [here](https://style.tidyverse.org/syntax.html#spacing)
+Run `air format` (or the `air` RStudio addin) to apply the project's spacing rules. For background on the underlying style, see the [tidyverse style guide on spacing](https://style.tidyverse.org/syntax.html#spacing).
 
 ## Global Variables and Constants
 
@@ -194,7 +194,7 @@ Use `<-`, not `=`, for assignment.
 
 Don't put `;` at the end of a line, and don't use `;` to put multiple commands on one line.
 
-**Note:** All these styling issues, and much more, are corrected automatically with `{styler}`.
+**Note:** All these styling issues, and much more, are corrected automatically by `air format`.
 
 ### Code blocks
 
@@ -235,7 +235,7 @@ Refer to chapter [Errors](https://style.tidyverse.org/errors.html)
 
 Package vignettes are written using `{rmarkdown}` package. Here are some good practices to follow while writing these documents:
 
-- It is strongly recommended that only alphanumeric characters (`a-z`, `A-Z` and `0-9`) and dashes (`-`) are used in chunk labels, because they are not special characters and will surely work for all output formats. Other characters, spaces and underscores in particular, may cause trouble in certain packages, such as `{bookdown}`, `{styler}`. 
+- It is strongly recommended that only alphanumeric characters (`a-z`, `A-Z` and `0-9`) and dashes (`-`) are used in chunk labels, because they are not special characters and will surely work for all output formats. Other characters, spaces and underscores in particular, may cause trouble in certain packages, such as `{bookdown}`. 
 Ref: <https://bookdown.org/yihui/rmarkdown/r-code.html>
 
 ````

--- a/ospsuite-r-specifics/collaboration_guide.md
+++ b/ospsuite-r-specifics/collaboration_guide.md
@@ -1,153 +1,180 @@
 # R Development Collaboration Guide
 
+This guide describes how to contribute to, review, and release OSPS R packages. It is intended for contributors, reviewers, and maintainers of the OSPS R projects.
+
+## Contents
+
+- [Rules](#rules)
+- [Prerequisites](#prerequisites)
+- [Contributing changes](#contributing-changes)
+- [Reviewing a pull request](#reviewing-a-pull-request)
+- [Releasing versions](#releasing-versions)
+
 ## Rules
 
-The following set of rules should be followed by all contributors and checked by
-all reviewers of the OSPS R projects.
+The following set of rules should be followed by all contributors and checked by all reviewers of the OSPS R projects.
 
-1. Each change made to the codebase should have a clear purpose and exist in an
-isolated context.  
+1. Each change made to the codebase should have a clear purpose and exist in an isolated context.  
   1.1 Each change should be related to an issue created on the project's repository.  
   1.2 Each change should be made in a separate branch.  
   1.3 Each change should be proposed through a pull request.
 
 2. Each change or addition to the code should be documented and controlled.  
-  2.1 Each change that affects **user experience or outputs** should be reflected in the documentation. If 
-  documentation is not present, then it should be created.  
-  2.2 Each change should be tested. If new cases emerge, then they should be 
-  tested, even if some tests are already present. If no tests are present, then
-  they should be created.
+  2.1 Each change that affects **user experience or outputs** should be reflected in the documentation. If documentation is not present, then it should be created.  
+  2.2 Each change should be tested. If new cases emerge, then they should be tested, even if some tests are already present. If no tests are present, then they should be created.
 
-3. Each change should be easily reviewable, understandable, and traceable.
-  3.1 Each change that affects **user experience or outputs** should have a corresponding entry in the `NEWS` file.
+3. Each change should be easily reviewable, understandable, and traceable.  
+  3.1 Each change that affects **user experience or outputs** should have a corresponding entry in the `NEWS.md` file.  
   3.2 Each change should be associated with a pull request whose scope is limited to the change itself.
 
-4. Each change must respect the coding style of the project.
-  4.1 Each change must respect the coding style of the project as defined in the [R Coding Standards](CODING_STANDARDS_R.md).
-  4.2 Each change must be processed by the `{styler}` package before being proposed.
+4. Each change must respect the coding style of the project.  
+  4.1 Each change must respect the coding style of the project as defined in the [R Coding Standards](CODING_STANDARDS_R.md).  
+  4.2 Each change must be processed by the [`air`](https://posit-dev.github.io/air/) formatter before being proposed.
 
-5. Each change should be reviewed before being merged.
-  5.1 Each change should be reviewed by at least one other contributor through its associated pull request.
+5. Each change should be reviewed before being merged.  
+  5.1 Each change should be reviewed by at least one other contributor through its associated pull request.  
   5.2 Each change should be functional and comply with these rules before its associated pull request is set as "ready for review". If not ready or reviewer inputs are needed, the pull request should be marked as "draft".
 
-## Recommended Workflows
+## Prerequisites
 
-### Changing Code
+The workflows in this guide assume that:
 
-The recommended workflow for contributing to the OSPS R projects heavily relies on the [`{usethis}`](https://usethis.r-lib.org) package and its family of functions [`pr_*()`](https://usethis.r-lib.org/articles/pr-functions.html).
+- R and RStudio are installed.
+- A GitHub account is available and set up to work with RStudio.
+- The `{usethis}` package is installed.
+- A local clone (from the original repository or from a fork) has been created.
 
-#### Prerequisites
+Releasing a version additionally assumes that the current branch is the default branch (usually `main`).
 
-This workflow implies that:
+## Contributing changes
 
--   R and RStudio are installed,
--   A GitHub account is available and set up to work with RStudio,
--   The `{usethis}` package is installed,
--   A local clone (from original repository or from a fork) has been created.
+Contributions to the OSPS R projects use the [`{usethis}`](https://usethis.r-lib.org) package and its family of [`pr_*()`](https://usethis.r-lib.org/articles/pr-functions.html) functions.
 
-#### Workflow
+1.  Initialize the branch with `usethis::pr_init("my-branch-name")`.
+2.  Apply changes in the codebase and save with commits.
+3.  Add or update tests covering the change.
+4.  Update `NEWS.md` if the change affects user experience or outputs.
+5.  Format edited `.R` files with `air format` (or the `air` RStudio addin).
+6.  Run `devtools::check()` locally and resolve any errors, warnings, or notes.
+7.  Make a pull request with `usethis::pr_push()`.
+8.  Address reviewer feedback with new commits, then run `usethis::pr_push()` again.
+9.  Once the pull request is merged, clean up the local branch with `usethis::pr_finish()`.
 
-1.  Initialize `usethis::pr_init("my-branch-name")`.
-2.  Apply changes in codebase and save with commits
-3.  Once changes are implemented, make a pull request with `usethis::pr_push()`.
-4.  Review of the pull request may ask for additional changes, proceed with commits then use the `pr_push()` command again.
-5.  Finally, the reviewer merges the pull request, the local branch can be cleaned away using `usethis::pr_finish()`
+**Tips:**
 
-#### Useful tips
+-   Get back to the default branch at any moment with `usethis::pr_pause()`.
+-   Retrieve an open pull request locally with `usethis::pr_fetch(XX)`, where `XX` is the pull request's numerical identifier.
 
--   At any moment you can get back to main branch using `usethis::pr_pause()`
--   If you need to make some changes on a branch that already has a pull request open, you can retrieve it locally with `usethis::pr_fetch(XX)` with `XX` being the pull request's numerical identifier.
+## Reviewing a pull request
 
-### Releasing Versions
-  
-#### Prerequisites
+Reviewers should verify the following before approving:
 
-This workflow implies that:
+- [ ] The pull request is linked to an issue and its scope is limited to that issue (Rules 1.1, 3.2).
+- [ ] CI checks pass.
+- [ ] Code follows the [R Coding Standards](CODING_STANDARDS_R.md) and is formatted with `air` (Rules 4.1, 4.2).
+- [ ] Tests cover the change and pass locally (Rule 2.2).
+- [ ] Documentation (roxygen, vignettes, pkgdown site) reflects user-facing changes (Rule 2.1).
+- [ ] `NEWS.md` has an entry when the change affects user experience or outputs (Rule 3.1).
+- [ ] The pull request description is clear and the commit history is readable.
 
-- R and RStudio are installed,
-- A GitHub account is available and set up to work with RStudio,
-- The `{usethis}` package is installed,
-- A local clone (from original repository or from a fork) has been created.
-- The current branch is the default branch (usually `main`).
+## Releasing versions
 
-#### Pre-release checklist
+### Versioning model
 
-Before starting the release process, verify the following:
+OSPS R packages use a two-state versioning model automated by the [`description_manager.yaml`](https://github.com/Open-Systems-Pharmacology/Workflows/blob/main/.github/workflows/description_manager.yaml) reusable GitHub workflow. The workflow runs on each push to the default branch and updates the `DESCRIPTION` file:
 
-- [ ] All CI checks pass on the branch to merge.
-- [ ] `NEWS` file is up to date and reflects all user-facing changes since the last release.
+- **Release versions** (for example, `0.2.0`) — the version is left untouched, a `v0.2.0` git tag is created, and entries in the `Remotes` field are pinned to `@*release` so the released package depends on released versions of other OSPS packages.
+- **Development versions** (for example, `0.2.0.9000`) — the fourth component is auto-incremented on every push to the default branch (`.9000` → `.9001` → ...), no tag is created, and `Remotes` entries remain unpinned.
 
-#### Workflow
+The `.9000`+ suffix distinguishes in-development builds from released versions; see the [R Packages versioning guide](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number) for background.
 
-The recommended workflow for releasing relies on the [`{usethis}`](https://usethis.r-lib.org) package.
+Because version bumps are automated, contributors **must not** manually edit the version field in `DESCRIPTION` outside of the release workflow described later in this section.
 
-##### Creating the release
+### Pre-release checklist
 
-1. Pick the new version number (refer to the [R Packages versioning guide](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number) to make the right choice).
-  ```r
-  new_version <- usethis:::choose_version("What should the new version be?")
-  ```
+Before releasing, verify the following on the default branch:
+
+- [ ] All CI checks pass on the latest commit.
+- [ ] `devtools::check()` runs locally with no errors, warnings, or notes.
+- [ ] The pkgdown site builds cleanly (`pkgdown::build_site()`).
+- [ ] `NEWS.md` is up to date and reflects all user-facing changes since the last release.
+- [ ] The chosen version number is consistent with [semantic versioning](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number) and the nature of the changes (major / minor / patch).
+
+### Creating the release
+
+1. Pick the new version number.
+   ```r
+   new_version <- usethis:::choose_version("What should the new version be?")
+   ```
 
 2. Create a dedicated branch.
-  ```r
-  usethis::pr_init(branch = paste0("release-v", new_version))
-  ```
+   ```r
+   usethis::pr_init(branch = paste0("release-v", new_version))
+   ```
 
-3. Automatically update the version number in the `DESCRIPTION` file. Follow the interactive prompts to accept and commit the changes.
-  ```r
-  usethis::use_version(which = labels(new_version))
-  ```
+3. Set the release version in `DESCRIPTION`. Follow the interactive prompts to accept and commit the changes.
+   ```r
+   usethis::use_version(which = labels(new_version))
+   ```
 
 4. Push the local branch and create the pull request.
-  ```r
-  usethis::pr_push()
-  ```
+   ```r
+   usethis::pr_push()
+   ```
 
 5. Once the pull request is approved and merged, clean up the local branch.
-  ```r
-  usethis::pr_finish()
-  ```
+   ```r
+   usethis::pr_finish()
+   ```
 
-##### Publishing the release
+### Publishing the release
 
-6. Wait until all CI/CD actions on the merge commit are validated and completed.
+1. Wait until all CI/CD actions on the merge commit are validated and completed. The `description_manager.yaml` workflow will:
+   - Detect the release version (no `.9000`+ suffix).
+   - Pin `Remotes` entries to `@*release`.
+   - Create the `v<version>` git tag.
+   - Commit the result back to the default branch.
 
-7. Switch to the default branch and pull the latest changes.
-  ```r
-  usethis::pr_pause()  # if on another branch
-  git pull              # from the terminal
-  ```
+2. Switch to the default branch and pull the latest changes.
+   ```r
+   usethis::pr_pause()  # if on another branch
+   git pull             # from the terminal
+   ```
 
-8. Create the release on GitHub.
-  ```r
-  usethis::use_github_release()
-  ```
+3. Create the release on GitHub.
+   ```r
+   usethis::use_github_release()
+   ```
 
-9. Download the built packages from the GitHub Actions run triggered by the PR merge and attach them to the release. The new version is now fully released!
+4. Download the built packages from the GitHub Actions run triggered by the PR merge and attach them to the release. The new version is now fully released.
 
-##### Restoring development mode
+### Restoring development mode
 
-10. Pick the development version number. Development versions end with `.9000` so that developers and users can easily distinguish them from release versions.
-  ```r
-  new_version <- usethis:::choose_version(which = "dev")
-  ```
+After the release tag is created, set the next development version. Subsequent pushes to the default branch will be auto-incremented by `description_manager.yaml`.
 
-11. Create a dedicated branch.
-  ```r
-  usethis::pr_init(branch = paste0("dev-v", new_version))
-  ```
+1. Pick the development version number. Development versions end with `.9000` so that developers and users can easily distinguish them from release versions.
+   ```r
+   new_version <- usethis:::choose_version(which = "dev")
+   ```
 
-12. Update the version number in the `DESCRIPTION` file. Follow the interactive prompts to accept and commit the changes.
-  ```r
-  usethis::use_version(which = labels(new_version))
-  ```
+2. Create a dedicated branch.
+   ```r
+   usethis::pr_init(branch = paste0("dev-v", new_version))
+   ```
 
-13. Push the local branch and create the pull request.
-  ```r
-  usethis::pr_push()
-  ```
+3. Set the development version in `DESCRIPTION`. Follow the interactive prompts to accept and commit the changes.
+   ```r
+   usethis::use_version(which = labels(new_version))
+   ```
 
-14. Once the pull request is approved and merged, clean up the local branch.
-  ```r
-  usethis::pr_finish()
-  ```
+4. Push the local branch and create the pull request.
+   ```r
+   usethis::pr_push()
+   ```
+
+5. Once the pull request is approved and merged, clean up the local branch.
+   ```r
+   usethis::pr_finish()
+   ```
+
+From this point on, `description_manager.yaml` auto-bumps the `.9000`+ suffix on every push to the default branch until the next release.

--- a/ospsuite-r-specifics/collaboration_guide.md
+++ b/ospsuite-r-specifics/collaboration_guide.md
@@ -76,6 +76,7 @@ Reviewers should verify the following before approving:
 - [ ] Documentation (roxygen, vignettes, pkgdown site) reflects user-facing changes (Rule 2.1).
 - [ ] `NEWS.md` has an entry when the change affects user experience or outputs (Rule 3.1).
 - [ ] The pull request description is clear and the commit history is readable.
+- [ ] In the case of an automated AI review of a pull request (e.g., CodeRabbit or GitHub Copilot), all improvements suggested by the AI reviewer must either be fixed or set to "Resolved" with a comment.
 
 ## Releasing versions
 


### PR DESCRIPTION
Restructures `ospsuite-r-specifics/collaboration_guide.md` for better readability and navigability. Adds a reviewer checklist, documents the `description_manager.yaml` versioning model, and refreshes references (formatter, `NEWS.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized collaboration guide with expanded sections on prerequisites, contribution workflow, PR review, and release procedures.
  * Added explicit contributor and reviewer checklists (CI, checks, site build, tests, docs).
  * Documented two-state versioning model for release vs. development builds and related release steps.
  * Updated coding standards to specify the `air` formatter (and `lintr`) and clarified RMarkdown chunk-label guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/developer-docs/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->